### PR TITLE
Update directory handling (check partials and allow multiple director…

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -73,4 +73,30 @@ describe('sass-lookup', function() {
         process.cwd() + '/example/nested/a/b/_b3.scss');
     });
   });
+
+  describe('multiple directories', function() {
+    it('handles partials in middle directory', function() {
+      var directories = ['example', 'example/nested/a/b', 'example/a'];
+      assert.equal(lookup('b', 'b2.scss', directories),
+        process.cwd() + '/example/nested/a/b/b.scss');
+    });
+
+    it('partial in last directory of list', function() {
+      var directories = ['example', 'example/nested/a/b'];
+      assert.equal(lookup('b', 'b2.scss', directories),
+        process.cwd() + '/example/nested/a/b/b.scss');
+    });
+
+    it('non-partial in last directory when given list', function() {
+      var directories = ['example', 'example/nested/a/b'];
+      assert.equal(lookup('b2', 'b3.scss', directories),
+        process.cwd() + '/example/nested/a/b/b2.scss');
+    });
+
+    it('handles underscored partials', function() {
+      var directories = ['example', 'example/nested/a/b'];
+      assert.equal(lookup('b2', 'b3.scss', directories),
+        process.cwd() + '/example/nested/a/b/b2.scss');
+    });
+  })
 });


### PR DESCRIPTION
Currently, the only directory checked for partials is the directory of `filename`, `directory` is not checked for partials.

This pull request checks `directory` and will also check multiple directories (if its not a string).

The function returned a value, even when a file couldn't be found-- so this function does the same, but only if `directory` is a string.

The patch and the testing could probably use some work. Critique welcome.